### PR TITLE
Add in support for appFonts for basic

### DIFF
--- a/src/configParamsJSON/basicConfigParams.json
+++ b/src/configParamsJSON/basicConfigParams.json
@@ -346,7 +346,7 @@
                   "config": {
                     "numOfSections": 1,
                     "headerOnly": true,
-                    "singleFont": true
+                    "singleFont": false
                   },
                   "defaultValue": null
                 }


### PR DESCRIPTION
Basic only has support for a few widgets so it was fairly straightforward to add in appfont support