### PR TITLE
Fix for issue with local testing

### DIFF
--- a/src/baseClasses/ApplicationBase.ts
+++ b/src/baseClasses/ApplicationBase.ts
@@ -527,7 +527,11 @@ export default class ApplicationBase {
   }
 
   private async _isPortalServer(): Promise<boolean> {
-    const testingUrl: string = `${this._getEsriEnvironmentPortalUrl()}/sharing/rest/info`;
+    const esriUrl = this._getEsriEnvironmentPortalUrl();
+    if(esriUrl == null){
+      return false;
+    }
+    const testingUrl: string = `${esriUrl}/sharing/rest/info`;
     try {
       const res: Response = await fetch(testingUrl, {
         method: 'HEAD'


### PR DESCRIPTION
The issue was that an "undefined" value was getting type coerced into a string, and then the full string "undefined/sharing/rest/info" was resolving with a `200` code from the fetch request for whatever reason