### PR TITLE
feat: add a way to update the view's calcite-mode class

### DIFF
--- a/src/functionality/configUtils.ts
+++ b/src/functionality/configUtils.ts
@@ -53,3 +53,20 @@ export function getSharedTheme(
 
   return sharedTheme;
 }
+
+//----------------------------------
+//  updateViewsCalciteMode
+//----------------------------------
+
+/**
+ * Update view's calcite-mode class when theme is updated
+ */
+
+export function updateViewsCalciteMode(theme: "light" | "dark"): void {
+  const prevCalciteTheme = theme === "light" ? "calcite-mode-dark" : "calcite-mode-light";
+  const calciteTheme = theme === "light" ? "calcite-mode-light" : "calcite-mode-dark";
+  const uiContainers = document.querySelectorAll(`.esri-ui.${prevCalciteTheme}`);
+  for (let i = 0; i < uiContainers.length; i++) {
+    uiContainers[i].className = uiContainers[i].className.replace(prevCalciteTheme, calciteTheme);
+  }
+}

--- a/src/functionality/configUtils.ts
+++ b/src/functionality/configUtils.ts
@@ -62,11 +62,11 @@ export function getSharedTheme(
  * Update view's calcite-mode class when theme is updated
  */
 
-export function updateViewsCalciteMode(theme: "light" | "dark"): void {
-  const prevCalciteTheme = theme === "light" ? "calcite-mode-dark" : "calcite-mode-light";
-  const calciteTheme = theme === "light" ? "calcite-mode-light" : "calcite-mode-dark";
-  const uiContainers = document.querySelectorAll(`.esri-ui.${prevCalciteTheme}`);
+export function updateViewsCalciteMode(mode: "light" | "dark"): void {
+  const prevCalciteMode = mode === "light" ? "calcite-mode-dark" : "calcite-mode-light";
+  const calciteMode = mode === "light" ? "calcite-mode-light" : "calcite-mode-dark";
+  const uiContainers = document.querySelectorAll(`.esri-ui.${prevCalciteMode}`);
   for (let i = 0; i < uiContainers.length; i++) {
-    uiContainers[i].className = uiContainers[i].className.replace(prevCalciteTheme, calciteTheme);
+    uiContainers[i].className = uiContainers[i].className.replace(prevCalciteMode, calciteMode);
   }
 }


### PR DESCRIPTION
When updating the mode to "light" or "dark" in the config panel, the view's calcite-mode class isn't being updated so added a helper function to replace the current class mode.


view's calcite-mode class isn't updated which could cause theme issues in preview window's UI if the view has any custom widgets that use  calcite components:
<img width="501" alt="image" src="https://user-images.githubusercontent.com/45497237/219760353-e831763c-8976-4ffb-a95a-f32e12c35f95.png">

<img width="402" alt="image" src="https://user-images.githubusercontent.com/45497237/219766673-47f77132-12de-4d40-a5c0-eb2c3a260d94.png">

