### PR TITLE
fix: remove table option from nearby/lookup

### DIFF
--- a/src/configParamsJSON/lookupConfigParams.json
+++ b/src/configParamsJSON/lookupConfigParams.json
@@ -589,12 +589,6 @@
                   "id": "layerListOpenAtStart",
                   "express": false,
                   "defaultValue": false
-                },
-                {
-                  "type": "setting",
-                  "id": "layerListAddTable",
-                  "express": false,
-                  "defaultValue": false
                 }
               ]
             },

--- a/src/configParamsJSON/nearbyConfigParams.json
+++ b/src/configParamsJSON/nearbyConfigParams.json
@@ -700,12 +700,6 @@
                   "id": "layerListOpenAtStart",
                   "express": false,
                   "defaultValue": false
-                },
-                {
-                  "type": "setting",
-                  "id": "layerListAddTable",
-                  "express": false,
-                  "defaultValue": false
                 }
               ]
             },


### PR DESCRIPTION
Remove the unsupported table option from these apps