### PR TITLE
feat: Add goToOverrides function that detects prefers-reduced-motion

### DIFF
--- a/src/structuralFunctionality/a11yUtils.ts
+++ b/src/structuralFunctionality/a11yUtils.ts
@@ -1,45 +1,56 @@
-
-
 const liveRegionId = "a11y-live-region";
 
 interface LiveRegionParams {
-    id?: string;
-    parent?: HTMLElement;
-    mode?: "polite" | "assertive";
+  id?: string;
+  parent?: HTMLElement;
+  mode?: "polite" | "assertive";
 }
 
 export function setupLiveRegion(params?: LiveRegionParams): HTMLElement {
-    const root = params?.parent ?? document.body;
-    const regionId = params?.id ?? liveRegionId;
-    const mode = params?.mode ?? "polite";
-    let region = root.querySelector<HTMLElement>(`#${regionId}`);
-    if (!region) {
-        region = document.createElement("div");
-        region.id = regionId;
-        region.classList.add("screen-readers-only");
-        region.setAttribute("role", "alert");
-        region.setAttribute("aria-live", mode);
-        region.setAttribute("aria-atomic", "true");
-        region.textContent = "";
-        root.appendChild(region);
-    }
-    return region;
+  const root = params?.parent ?? document.body;
+  const regionId = params?.id ?? liveRegionId;
+  const mode = params?.mode ?? "polite";
+  let region = root.querySelector<HTMLElement>(`#${regionId}`);
+  if (!region) {
+    region = document.createElement("div");
+    region.id = regionId;
+    region.classList.add("screen-readers-only");
+    region.setAttribute("role", "alert");
+    region.setAttribute("aria-live", mode);
+    region.setAttribute("aria-atomic", "true");
+    region.textContent = "";
+    root.appendChild(region);
+  }
+  return region;
 }
 
 export function postToLiveRegion(message: string, id?: string) {
-    const regionId = id ? id : liveRegionId;
-    const region = document.body.querySelector<HTMLElement>(`#${regionId}`);
-    if (region) {
-        region.textContent = message;
-    }
+  const regionId = id ? id : liveRegionId;
+  const region = document.body.querySelector<HTMLElement>(`#${regionId}`);
+  if (region) {
+    region.textContent = message;
+  }
 }
 export function prefersReducedMotion(): boolean {
-    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    return mediaQuery.matches ? true : false;
+  const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+  return mediaQuery.matches ? true : false;
 }
-
+export function goToOverride(
+  view: __esri.MapView | __esri.SceneView,
+  goToParams: any
+) {
+  if (prefersReducedMotion()) {
+    goToParams.options = {
+      ...goToParams.options,
+      ...{
+        animate: false,
+      },
+    };
+  }
+  return view.goTo(goToParams.target, goToParams.options);
+}
 export default {
-    setupLiveRegion,
-    prefersReducedMotion,
-    postToLiveRegion
+  setupLiveRegion,
+  prefersReducedMotion,
+  postToLiveRegion,
 };

--- a/src/structuralFunctionality/a11yUtils.ts
+++ b/src/structuralFunctionality/a11yUtils.ts
@@ -42,9 +42,7 @@ export function goToOverride(
   if (prefersReducedMotion()) {
     goToParams.options = {
       ...goToParams.options,
-      ...{
-        animate: false,
-      },
+      animate: false,
     };
   }
   return view.goTo(goToParams.target, goToParams.options);


### PR DESCRIPTION
Added a function that checks to see if prefers reduced motion is enabled and if so it disables it for goTo. Can be used as the goToOverride function for popup and search. Here's a sample showing how its set for the popup and search widgets. 

https://codepen.io/kellyhutchins/pen/bGxqWwg?editors=0010