### PR TITLE
createSearch fix

### DIFF
--- a/src/functionality/search.ts
+++ b/src/functionality/search.ts
@@ -100,7 +100,7 @@ export function createSearch(
   });
 
   const searchWidget_t9n = searchWidget?.["messages"];
-  if (searchWidget.allPlaceholder === DEFAULT_PLACEHOLDER) searchWidget.allPlaceholder = searchWidget_t9n.allPlaceholder;
+  if (searchWidget.allPlaceholder === DEFAULT_PLACEHOLDER) searchWidget.allPlaceholder = searchWidget_t9n?.allPlaceholder;
 
   return searchWidget;
 }

--- a/src/functionality/search.ts
+++ b/src/functionality/search.ts
@@ -48,6 +48,7 @@ export function createSearch(
   portal: Portal,
   searchConfiguration: SearchConfiguration
 ): Search {
+  const DEFAULT_PLACEHOLDER = "Find address or place";
   const INCLUDE_DEFAULT_SOURCES = "includeDefaultSources";
   const sources = searchConfiguration?.sources;
 
@@ -70,7 +71,7 @@ export function createSearch(
         const locatorSource = source as LocatorSourceConfigItem;
         if (locatorSource?.name === "ArcGIS World Geocoding Service") {
           if (!locatorSource?.placeholder)
-            locatorSource.placeholder = "Find address or place";
+            locatorSource.placeholder = DEFAULT_PLACEHOLDER;
           const outFields = locatorSource.outFields || [
             "Addr_type",
             "Match_addr",
@@ -92,9 +93,14 @@ export function createSearch(
     };
   }
 
-  return new Search({
+   const searchWidget = new Search({
     view,
     portal,
     ...searchConfiguration,
   });
+
+  const searchWidget_t9n = searchWidget?.["messages"];
+  if (searchWidget.allPlaceholder === DEFAULT_PLACEHOLDER) searchWidget.allPlaceholder = searchWidget_t9n.allPlaceholder;
+
+  return;
 }

--- a/src/functionality/search.ts
+++ b/src/functionality/search.ts
@@ -102,5 +102,5 @@ export function createSearch(
   const searchWidget_t9n = searchWidget?.["messages"];
   if (searchWidget.allPlaceholder === DEFAULT_PLACEHOLDER) searchWidget.allPlaceholder = searchWidget_t9n.allPlaceholder;
 
-  return;
+  return searchWidget;
 }


### PR DESCRIPTION
This update checks for the `en` string `Find address or place`, and replaces the search widget's allPlaceholder property with the translated allPlaceholder string.