### PR TITLE
Update nearbyConfigParams.json

### DIFF
--- a/src/configParamsJSON/nearbyConfigParams.json
+++ b/src/configParamsJSON/nearbyConfigParams.json
@@ -287,7 +287,7 @@
                 }
               ],
               "defaultValue": {
-                "branchValue": "search-extent",
+                "branchValue": "search-radius",
                 "branchOptionsFieldNames": []
               }
             }


### PR DESCRIPTION
Go back to search radius as default for nearby until we optimize for too many features in extent.