### PR TITLE
fix: Remove unused position prop

### DIFF
--- a/src/configParamsJSON/managerConfigParams.json
+++ b/src/configParamsJSON/managerConfigParams.json
@@ -80,17 +80,7 @@
                   "type": "setting",
                   "id": "fullScreen",
                   "express": false,
-                  "defaultValue": true,
-                  "content": [
-                    {
-                      "type": "setting",
-                      "id": "fullScreenPosition",
-                      "defaultValue": {
-                        "position": "bottom-right",
-                        "index": 0
-                      }
-                    }
-                  ]
+                  "defaultValue": true
                 }
               ]
             }


### PR DESCRIPTION
The config for manager shouldn't allow for positioning the widgets. 