### PR TITLE
fix: language switcher overwrite logic

### DIFF
--- a/src/structuralFunctionality/language-switcher/LanguageSwitcher.tsx
+++ b/src/structuralFunctionality/language-switcher/LanguageSwitcher.tsx
@@ -28,10 +28,9 @@ import { getLocale, normalizeMessageBundleLocale } from "esri/intl";
 import PortalItem from "esri/portal/PortalItem";
 import { isWithinConfigurationExperience } from "../../functionality/configurationSettings";
 import { LanguageData } from "./support/interfaces";
-import { CSS, HANDLES_KEY, NODE_ID } from "./support/constants";
+import { CSS, HANDLES_KEY, NODE_ID, NO_DEFAULT_FIELDS, PREVENT_OVERWRITE } from "./support/constants";
 import { Defaults, ProperyNames } from "./support/enums";
 
-const NO_DEFAULT_FIELDS = ["title"];
 
 @subclass("LanguageSwitcher")
 export default class LanguageSwitcher extends Widget {
@@ -329,7 +328,11 @@ export default class LanguageSwitcher extends Widget {
   // Prevents the current values from being overwritten with a stale value
   private _preventOverwrite(config): void {
     for (const key in config) {
-      if (typeof config[key] !== "string") {
+      const keyLowerCase = key.toLowerCase();
+      const isColor = keyLowerCase.includes("color");
+      const isPosition = keyLowerCase.includes("position");
+      const preventOverwrite = PREVENT_OVERWRITE.indexOf(key) !== -1;
+      if (typeof config[key] !== "string" || isColor || isPosition || preventOverwrite) {
         delete config[key];
       }
     }

--- a/src/structuralFunctionality/language-switcher/LanguageSwitcher.tsx
+++ b/src/structuralFunctionality/language-switcher/LanguageSwitcher.tsx
@@ -328,9 +328,10 @@ export default class LanguageSwitcher extends Widget {
 
   // Prevents the current values from being overwritten with a stale value
   private _preventOverwrite(config): void {
-    delete config.languageSwitcher;
-    delete config.languageSwitcherOpenAtStart;
-    delete config.languageSwitcherPosition;
-    delete config.languageSwitcherConfig;
+    for (const key in config) {
+      if (typeof config[key] !== "string") {
+        delete config[key];
+      }
+    }
   }
 }

--- a/src/structuralFunctionality/language-switcher/support/constants.ts
+++ b/src/structuralFunctionality/language-switcher/support/constants.ts
@@ -5,3 +5,43 @@ export const CSS = {
 export const HANDLES_KEY = "language-switcher-handles";
 
 export const NODE_ID = "esri-language-switcher";
+
+export const NO_DEFAULT_FIELDS = ["title"];
+
+export const PREVENT_OVERWRITE = [
+  "portalUrl",
+  "appid",
+  "exportButtonIcon",
+  "displayUnmatchedResults",
+  "oauthappid",
+  "units",
+  "webmap",
+  "webscene",
+  "locale",
+  "type",
+  "spatialRelationship",
+  "directionsUnit",
+  "mapPinIcon",
+  "theme",
+  "customCSS",
+  "panelSize",
+  "titleLink",
+  "basemapSelector",
+  "proxyUrl",
+  "interactiveLegendPanelLocation",
+  "customURLParamName",
+  "localeIcon",
+  "elevationProfileUnits",
+  "coordinateFormats",
+  "swipeDirection",
+  "printCopyright",
+  "durationPeriod",
+  "timeIntervalUnits",
+  "infoButtonIcon",
+  "splashButtonIcon",
+  "layoutType",
+  "localeSwitcherLabel",
+  "activePanel",
+  "relationship",
+  "searchUnits"
+];


### PR DESCRIPTION
This fix prevents non-string and non-translatable values to be overwritten when using the language switcher. 