### PR TITLE
fix: We don't always have values if the app isn't initialized with an…

### DIFF
--- a/src/structuralFunctionality/landing-page/LandingPage.tsx
+++ b/src/structuralFunctionality/landing-page/LandingPage.tsx
@@ -156,7 +156,7 @@ class LandingPage extends Widget {
   }
 
   private _handleDeprecatedCoverPage(): void {
-    const values = this.base.results.applicationData.value.values;
+    const values = this.base.results.applicationData?.value?.values;
     KEYS.forEach((key) =>
       this._handleUndefined(values, key, this.configurationSettings)
     );


### PR DESCRIPTION
somtimes we just initialize the app with a web map so this logs an error to console