### PR TITLE
fix: Remove language switcher from beta app

### DIFF
--- a/src/configParamsJSON/reporterConfigParams.json
+++ b/src/configParamsJSON/reporterConfigParams.json
@@ -580,38 +580,6 @@
           ]
         }
       ]
-    },
-    {
-      "type": "section",
-      "id": "languageSwitcher",
-      "express": false,
-      "content": [
-        {
-          "type": "setting",
-          "id": "languageSwitcher",
-          "defaultValue": false,
-          "content": [
-            {
-              "type": "setting",
-              "id": "languageSwitcherOpenAtStart",
-              "defaultValue": false
-            },
-            {
-              "type": "setting",
-              "id": "languageSwitcherConfig",
-              "defaultValue": null
-            },
-            {
-              "type": "setting",
-              "id": "languageSwitcherPosition",
-              "defaultValue": {
-                "position": "top-right",
-                "index": 0
-              }
-            }
-          ]
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
FYI @bcree11  we are removing this because the app is beta and if there are late translations etc things could get weird. 