### PR TITLE
fix: Move help panel to upper left corner

### DIFF
--- a/src/configParamsJSON/streamflowConfigParams.json
+++ b/src/configParamsJSON/streamflowConfigParams.json
@@ -67,7 +67,7 @@
                                     "type": "setting",
                                     "id": "helpPosition",
                                     "defaultValue": {
-                                        "position": "bottom-right",
+                                        "position": "top-left",
                                         "index": 0
                                     }
                                 }


### PR DESCRIPTION
Update. location of help panel in streamflow