### PR TITLE
feat: Add transparent support to sidebar

### DIFF
--- a/src/configParamsJSON/sidebarConfigParams.json
+++ b/src/configParamsJSON/sidebarConfigParams.json
@@ -581,6 +581,9 @@
                   "type": "setting",
                   "id": "highlightColor",
                   "express": false,
+                  "config": {
+                    "alpha": true
+                  },
                   "defaultValue": "#00FFFF"
                 }
               ]
@@ -594,6 +597,9 @@
                   "type": "setting",
                   "id": "highlightHaloColor",
                   "express": false,
+                  "config": {
+                    "alpha": true
+                  },
                   "defaultValue": "#00FFFF"
                 }
               ]


### PR DESCRIPTION
Updated to add transparent support to Sidebar. @brandon there is an enhancement to add to Insets too. Transparency could work for this or we could enhance the config to allow for no-color too. 