### PR TITLE
fix: Only apply transparent value if the color isn't hex. Otherwise u…

### DIFF
--- a/src/configParamsJSON/lookupConfigParams.json
+++ b/src/configParamsJSON/lookupConfigParams.json
@@ -728,7 +728,7 @@
                         "alpha": true
                       },
                       "express": false,
-                      "defaultValue": "#00FFFF"
+                      "defaultValue": "rgba(0, 255, 255, 0.25)"
                     }
                   ]
                 },
@@ -744,7 +744,7 @@
                         "alpha": true
                       },
                       "express": false,
-                      "defaultValue": "#00FFFF"
+                      "defaultValue": "rgba(0, 255, 255, 1)"
                     }
                   ]
                 },

--- a/src/configParamsJSON/nearbyConfigParams.json
+++ b/src/configParamsJSON/nearbyConfigParams.json
@@ -776,7 +776,7 @@
                         "alpha": true
                       },
                       "express": false,
-                      "defaultValue": "#00FFFF"
+                      "defaultValue": "rgba(0, 255, 255, 0.25)"
                     }
                   ]
                 },
@@ -792,7 +792,7 @@
                         "alpha": true
                       },
                       "express": false,
-                      "defaultValue": "#00FFFF"
+                      "defaultValue": "rgba(0, 255, 255, 1)"
                     }
                   ]
                 },

--- a/src/configParamsJSON/sidebarConfigParams.json
+++ b/src/configParamsJSON/sidebarConfigParams.json
@@ -584,7 +584,7 @@
                   "config": {
                     "alpha": true
                   },
-                  "defaultValue": "#00FFFF"
+                  "defaultValue": "rgba(0, 255, 255, 0.25)"
                 }
               ]
             },
@@ -600,7 +600,7 @@
                   "config": {
                     "alpha": true
                   },
-                  "defaultValue": "#00FFFF"
+                  "defaultValue": "rgba(0, 255, 255, 1)"
                 }
               ]
             },

--- a/src/functionality/highlight.ts
+++ b/src/functionality/highlight.ts
@@ -16,6 +16,10 @@ export function handleHighlightColors(
     highlightHaloColor,
   } = highlightConfig;
 
+  const isColorHex = /^#[0-9A-F]{6}$/i;
+  const highlightHexColor = isColorHex.test(highlightColor);
+  const highlightHaloHexColor = isColorHex.test(highlightHaloColor);
+
   const colorValue =
     enableHighlightColor && highlightColor
       ? highlightColor
@@ -28,12 +32,13 @@ export function handleHighlightColors(
 
   const color = new Color(colorValue);
   const haloColor = haloColorValue ? new Color(haloColorValue) : null;
+
   // https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html#highlightOptions
   view.highlightOptions = {
     ...highlightOptions,
     color, // jsapi default value is `#00ffff`
     haloColor, // jsapi default value is `null`, which sets halo to default Cyan color (#00ffff)
-    haloOpacity: haloColor?.a ? haloColor.a : 1, // jsapi default value is 1
-    fillOpacity: color?.a ? color.a : 0.25, // jsapi default value is 0.25
+    haloOpacity: !highlightHaloHexColor && haloColor?.a ? haloColor.a : 1, // jsapi default value is 1
+    fillOpacity: !highlightHexColor && color?.a ? color.a : 0.25, // jsapi default value is 0.25
   };
 }


### PR DESCRIPTION
…se the api defaults.


- Added logic to check and see if a hex color is provided and if so use default transparency
- If a rgba value is set then use the transparency the user defines. 