### PR TITLE
chore: Remove related records from Nearby Lookup

### DIFF
--- a/src/configParamsJSON/lookupConfigParams.json
+++ b/src/configParamsJSON/lookupConfigParams.json
@@ -344,12 +344,6 @@
                 },
                 {
                   "type": "setting",
-                  "id": "relatedRecords",
-                  "express": false,
-                  "defaultValue": null
-                },
-                {
-                  "type": "setting",
                   "id": "exportToPDF",
                   "express": false,
                   "defaultValue": false,

--- a/src/configParamsJSON/nearbyConfigParams.json
+++ b/src/configParamsJSON/nearbyConfigParams.json
@@ -473,12 +473,6 @@
               "content": [
                 {
                   "type": "setting",
-                  "id": "relatedRecords",
-                  "express": false,
-                  "defaultValue": null
-                },
-                {
-                  "type": "setting",
                   "id": "includeDistance",
                   "express": false,
                   "defaultValue": true


### PR DESCRIPTION
Removing this option since they'll get related records by default now. 

