### PR TITLE
chore: Remove theme option for streamflow

### DIFF
--- a/src/configParamsJSON/streamflowConfigParams.json
+++ b/src/configParamsJSON/streamflowConfigParams.json
@@ -453,12 +453,6 @@
                     "id": "theme",
                     "content": [
                         {
-                            "type": "setting",
-                            "id": "theme",
-                            "defaultValue": "light",
-                            "express": true
-                        },
-                        {
                             "type": "group",
                             "id": "headerTheme",
                             "content": [


### PR DESCRIPTION
Remove light/dark theme option from streamflow since currently only light is supported