### PR TITLE
chore: Add link chart support to Basic

### DIFF
--- a/src/configParamsJSON/basicConfigParams.json
+++ b/src/configParamsJSON/basicConfigParams.json
@@ -6,7 +6,8 @@
       "config": {
         "itemTypes": [
           "2d",
-          "3d"
+          "3d",
+          "weblinkchart"
         ]
       },
       "content": [


### PR DESCRIPTION
Add new option to support link charts in one app for Enterprise 11.5