### PR TITLE
feat: add the Slice tool to the library

### DIFF
--- a/src/functionality/esriWidgetUtils.ts
+++ b/src/functionality/esriWidgetUtils.ts
@@ -35,6 +35,7 @@ import { checkForElement } from "./generalUtils";
 import { createSearch, handleSearchExtent } from "./search";
 import ApplicationBase from "../baseClasses/ApplicationBase";
 import { ApplicationConfig } from "../interfaces/applicationBase";
+import Widget from "esri/widgets/Widget";
 
 interface esriSceneWidgetProps {
   config: ApplicationConfig;
@@ -1061,7 +1062,7 @@ export async function addSlice(props: esriSceneWidgetProps) {
   const expandNode = view.ui.find(expandId) as __esri.Expand;
   if (!slice) {
     if (expandNode) {
-      const slicePanel = expandNode?.content as any;
+      const slicePanel = expandNode?.content as Widget;
       if (slicePanel) slicePanel.destroy();
       view.ui.remove(expandNode);
     }

--- a/src/functionality/esriWidgetUtils.ts
+++ b/src/functionality/esriWidgetUtils.ts
@@ -23,7 +23,6 @@ import LayerList from "esri/widgets/LayerList";
 import Legend from "esri/widgets/Legend";
 import Locate from "esri/widgets/Locate";
 import Scalebar from "esri/widgets/ScaleBar";
-import SceneView from "esri/views/SceneView";
 import Viewpoint from "esri/Viewpoint";
 import Weather from "esri/widgets/Weather";
 import Zoom from "esri/widgets/Zoom";

--- a/src/functionality/esriWidgetUtils.ts
+++ b/src/functionality/esriWidgetUtils.ts
@@ -23,9 +23,12 @@ import LayerList from "esri/widgets/LayerList";
 import Legend from "esri/widgets/Legend";
 import Locate from "esri/widgets/Locate";
 import Scalebar from "esri/widgets/ScaleBar";
+import Slice from "esri/widgets/Slice";
 import Viewpoint from "esri/Viewpoint";
 import Weather from "esri/widgets/Weather";
 import Zoom from "esri/widgets/Zoom";
+
+import SlicePanel from "../structuralFunctionality/widgets/slice/SlicePanel";
 
 import { getBasemaps, resetBasemapsInToggle } from "./basemapToggle";
 import { checkForElement } from "./generalUtils";
@@ -912,7 +915,7 @@ export function addWeather(props: esriSceneWidgetProps) {
   if(!Weather) return;
   const { config, view, commonMessages, propertyName } = props;
   const { showWeather, weatherPosition } = config;
-  const expandId = "weatherExpand";
+  const expandId = "esri-weatherExpand";
   const expandNode = view.ui.find(expandId) as __esri.Expand;
 
   if (!showWeather) {
@@ -971,7 +974,7 @@ export function addDaylight(props: esriSceneWidgetProps) {
     daylightDateOrSeason,
     daylightOpenAtStart
   } = config;
-  const expandId = "daylightExpand";
+  const expandId = "esri-daylightExpand";
   const expandNode = view.ui.find(expandId) as __esri.Expand;
 
   if (!daylight) {
@@ -1041,5 +1044,61 @@ export function addDaylight(props: esriSceneWidgetProps) {
     });
 
     view.ui.add(daylightExpand, daylightPosition);
+  }
+}
+
+/**
+ * Watch for changes in slice, slicePosition, sliceOpenAtStart
+ */
+export async function addSlice(props: esriSceneWidgetProps) {
+  if (!Slice) return;
+  const { view, config, commonMessages, propertyName } = props;
+  const { slice, slicePosition, sliceOpenAtStart } = config;
+  const sceneView = view as __esri.SceneView;
+
+  const expandId = "esri-sliceExpand";
+  const expandNode = view.ui.find(expandId) as __esri.Expand;
+  if (!slice) {
+    if (expandNode) {
+      const slicePanel = expandNode?.content as any;
+      if (slicePanel) slicePanel.destroy();
+      view.ui.remove(expandNode);
+    }
+    return;
+  }
+
+  const group = getPosition(slicePosition);
+  const expanded = sliceOpenAtStart && !containsExpandedComponent(group, view);
+  const tip = commonMessages?.tools?.slice;
+
+  if ((propertyName === "slicePosition" || propertyName === "sliceOpenAtStart") && expandNode) {
+    if (propertyName === "sliceOpenAtStart") {
+      expanded ? expandNode.expand() : expandNode.collapse();
+    }
+    if (propertyName === "slicePosition") {
+      expandNode.collapseTooltip = tip;
+      expandNode.expandTooltip = tip;
+      expandNode.group = group;
+      view.ui.move(expandNode, slicePosition);
+    }
+  } else if (propertyName === "slice") {
+    const content = new SlicePanel({
+      config,
+      view: sceneView
+    });
+
+    const sliceExpand = new Expand({
+      id: expandId,
+      content,
+      group,
+      expandIcon: "slice",
+      mode: "floating",
+      expandTooltip: tip,
+      collapseTooltip: tip,
+      expanded,
+      view
+    });
+
+    view.ui.add(sliceExpand, slicePosition);
   }
 }

--- a/src/structuralFunctionality/widgets/slice/SlicePanel.tsx
+++ b/src/structuralFunctionality/widgets/slice/SlicePanel.tsx
@@ -49,7 +49,7 @@ class SlicePanel extends Widget {
   @messageBundle("dist/assets/t9n/common")
   messages: any = null;
 
-  sliceTool: __esri.Slice = null;
+  private sliceTool: __esri.Slice = null;
 
   private _createSliceTool(container: string | HTMLElement): void {
     this.sliceTool = new Slice({
@@ -74,7 +74,7 @@ class SlicePanel extends Widget {
 
   render() {
     const { theme } = this.config;
-    let themeClass = theme === "dark" ? "calcite-mode-dark" : "calcite-mode-light";
+    const themeClass = theme === "dark" ? "calcite-mode-dark" : "calcite-mode-light";
 
     return (
       <calcite-panel class={this.classes([theme, CSS.base, themeClass])}>

--- a/src/structuralFunctionality/widgets/slice/SlicePanel.tsx
+++ b/src/structuralFunctionality/widgets/slice/SlicePanel.tsx
@@ -23,12 +23,15 @@ import Slice from "esri/widgets/Slice";
 import { ApplicationConfig } from "../../../interfaces/applicationBase";
 
 interface SliceProps extends __esri.WidgetProperties {
-  config: any;
+  config: ApplicationConfig;
   view: __esri.SceneView;
 }
 
 const CSS = {
-  base: "slice-panel"
+  base: "slice-panel",
+  esriButton: "esri-button",
+  esriSecondaryButton: "esri-button--secondary",
+  sliceButton: "slice-button"
 };
 
 @subclass("SlicePanel")
@@ -46,10 +49,25 @@ class SlicePanel extends Widget {
   @messageBundle("dist/assets/t9n/common")
   messages: any = null;
 
-  @property()
-  rootNode: any = null;
   sliceTool: __esri.Slice = null;
 
+  private _createSliceTool(container: string | HTMLElement): void {
+    this.sliceTool = new Slice({
+      view: this.view,
+      container
+    });
+    this.sliceTool.viewModel.tiltEnabled = true;
+  }
+  private _handleSliceClear(): void {
+    if (!this.sliceTool) {
+      return;
+    }
+    this.sliceTool.viewModel.clear();
+  }
+
+  /**
+   * Lifecycle Methods
+   */
   constructor(params: SliceProps) {
     super(params);
   }
@@ -63,7 +81,7 @@ class SlicePanel extends Widget {
         <div bind={this} afterCreate={this._createSliceTool}></div>
         <div style="margin:0 15px 8px 15px;">
           <button
-            class="esri-button esri-button--secondary slice-button"
+            class={this.classes(CSS.esriButton, CSS.esriSecondaryButton, CSS.sliceButton)}
             disabled={this.state === "sliced" ? false : true}
             onclick={this._handleSliceClear}
             bind={this}
@@ -75,27 +93,20 @@ class SlicePanel extends Widget {
       </calcite-panel>
     );
   }
-  _createSliceTool(container) {
-    this.sliceTool = new Slice({
-      view: this.view,
-      container
-    });
-    this.sliceTool.viewModel.tiltEnabled = true;
-    watch(
-      () => this?.sliceTool?.viewModel?.state,
-      (state) => {
-        this.state = state;
-      },
-      { initial: true }
-    );
+
+  postInitialize(): void {
+    this.addHandles([
+      watch(
+        () => this?.sliceTool?.viewModel?.state,
+        (state) => {
+          this.state = state;
+        },
+        { initial: true }
+      )
+    ]);
   }
-  _handleSliceClear() {
-    if (!this.sliceTool) {
-      return;
-    }
-    this.sliceTool.viewModel.clear();
-  }
-  destroy() {
+
+  destroy(): void {
     this?.sliceTool?.destroy();
   }
 }

--- a/src/structuralFunctionality/widgets/slice/SlicePanel.tsx
+++ b/src/structuralFunctionality/widgets/slice/SlicePanel.tsx
@@ -1,0 +1,103 @@
+/*
+ *   Copyright (c) 2025 Esri
+ *   All rights reserved.
+
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+import { subclass, property } from "esri/core/accessorSupport/decorators";
+import { watch } from "esri/core/reactiveUtils";
+import Widget from "esri/widgets/Widget";
+import { tsx, messageBundle } from "esri/widgets/support/widget";
+import Slice from "esri/widgets/Slice";
+import { ApplicationConfig } from "../../../interfaces/applicationBase";
+
+interface SliceProps extends __esri.WidgetProperties {
+  config: any;
+  view: __esri.SceneView;
+}
+
+const CSS = {
+  base: "slice-panel"
+};
+
+@subclass("SlicePanel")
+class SlicePanel extends Widget {
+  @property()
+  config: ApplicationConfig;
+
+  @property()
+  view: __esri.SceneView;
+
+  @property()
+  state: string = null;
+
+  @property()
+  @messageBundle("dist/assets/t9n/common")
+  messages: any = null;
+
+  @property()
+  rootNode: any = null;
+  sliceTool: __esri.Slice = null;
+
+  constructor(params: SliceProps) {
+    super(params);
+  }
+
+  render() {
+    const { theme } = this.config;
+    let themeClass = theme === "dark" ? "calcite-mode-dark" : "calcite-mode-light";
+
+    return (
+      <calcite-panel class={this.classes([theme, CSS.base, themeClass])}>
+        <div bind={this} afterCreate={this._createSliceTool}></div>
+        <div style="margin:0 15px 8px 15px;">
+          <button
+            class="esri-button esri-button--secondary slice-button"
+            disabled={this.state === "sliced" ? false : true}
+            onclick={this._handleSliceClear}
+            bind={this}
+            theme={theme}
+          >
+            {this.messages.clear}
+          </button>
+        </div>
+      </calcite-panel>
+    );
+  }
+  _createSliceTool(container) {
+    this.sliceTool = new Slice({
+      view: this.view,
+      container
+    });
+    this.sliceTool.viewModel.tiltEnabled = true;
+    watch(
+      () => this?.sliceTool?.viewModel?.state,
+      (state) => {
+        this.state = state;
+      },
+      { initial: true }
+    );
+  }
+  _handleSliceClear() {
+    if (!this.sliceTool) {
+      return;
+    }
+    this.sliceTool.viewModel.clear();
+  }
+  destroy() {
+    this?.sliceTool?.destroy();
+  }
+}
+
+export default SlicePanel;

--- a/src/structuralFunctionality/widgets/slice/SlicePanel.tsx
+++ b/src/structuralFunctionality/widgets/slice/SlicePanel.tsx
@@ -57,7 +57,16 @@ class SlicePanel extends Widget {
       container
     });
     this.sliceTool.viewModel.tiltEnabled = true;
+
+    watch(
+      () => this?.sliceTool?.viewModel?.state,
+      (state) => {
+        this.state = state;
+      },
+      { initial: true }
+    );
   }
+
   private _handleSliceClear(): void {
     if (!this.sliceTool) {
       return;


### PR DESCRIPTION
### Release
**June 2025**

### Summary
Add the Slice tool to the widget utilities so it can be used in multiple Instant Apps.

### Testing (local dev)
* Replaced the `addSlice(...)` call from the widget utils in 3D Viewer with a call to the function of the same name within TCL
* Confirmed the Slice functioned as expected
* Confirmed the tool location changes as expected when modified via the position manager

### Notes
Copied from #598 