### PR TITLE
feat: add feature selection mode setting for Manager

### DIFF
--- a/src/configParamsJSON/managerConfigParams.ts
+++ b/src/configParamsJSON/managerConfigParams.ts
@@ -241,6 +241,12 @@ export default {
               "content": [
                 {
                   "type": "setting",
+                  "id": "featureSelectionMode",
+                  "express": false,
+                  "defaultValue": "multiple"
+                },
+                {
+                  "type": "setting",
                   "id": "mapItemLayerSelector",
                   "express": false,
                   "config": {


### PR DESCRIPTION
## Summary
Adds an option on the Manager config to control feature selection (`multiple` or `single`)