### PR TITLE
chore(manager): rename setting in prep for new Layer Options setting

### DIFF
--- a/src/configParamsJSON/managerConfigParams.ts
+++ b/src/configParamsJSON/managerConfigParams.ts
@@ -232,7 +232,7 @@ export default {
         },
         {
           "type": "subsection",
-          "id": "layerOptions",
+          "id": "tableOptions",
           "content": [
             {
               "type": "group",


### PR DESCRIPTION
## Summary

We will add a new section **Layer Options** to the config along with a corresponding setting. This change renames the **Table Options** setting `layerOptions` -> `tableOptions` to avoid confusion