### PR TITLE
fix(search): move search-complete logic to createSearch

### DIFF
--- a/src/functionality/esriWidgetUtils.ts
+++ b/src/functionality/esriWidgetUtils.ts
@@ -494,29 +494,7 @@ export function addSearch(
   const map = view.map as __esri.WebMap | __esri.WebScene;
   const portal = map.portalItem?.portal;
   const tmpSearchConfig = JSON.parse(JSON.stringify(searchConfiguration));
-  const searchWidget = createSearch(view, portal, tmpSearchConfig);
-  searchWidget.on("search-complete", () => {
-    if (searchWidget.popupEnabled) {
-      // Handle setting focus on popup and then back
-      // to search box
-      if (popupHover) view.popupEnabled = true;
-      when(
-        () => view?.popup?.viewModel?.active === true,
-        () => {
-          view.popup.focus();
-          when(
-            () => view?.popup?.visible === false,
-            () => {
-              searchWidget.focus();
-              if (popupHover) view.popupEnabled = false;
-            },
-            { initial: true, once: true }
-          );
-        },
-        { initial: true, once: true }
-      );
-    }
-  });
+  const searchWidget = createSearch(view, portal, tmpSearchConfig, popupHover);
   node = new Expand({
     view,
     content: searchWidget,

--- a/src/functionality/search.ts
+++ b/src/functionality/search.ts
@@ -46,6 +46,19 @@ interface SearchConfiguration {
   sources?: Array<LocatorSourceConfigItem | LayerSourceConfigItem>;
 }
 
+/**
+ * Creates and configures an ArcGIS Search widget for a given view and portal.
+ *
+ * This function sets up the search sources based on the provided configuration,
+ * handling both locator and layer sources. It also manages placeholder localization,
+ * popup focus behavior, and default source inclusion.
+ *
+ * @param view - The MapView or SceneView instance to associate with the Search widget.
+ * @param portal - The ArcGIS Portal instance for context.
+ * @param searchConfiguration - The configuration object specifying search sources and options.
+ * @param popupHover - Optional. If true, enables popup on hover and manages focus between popup and search box.
+ * @returns The configured Search widget.
+ */
 export function createSearch(
   view: __esri.MapView | __esri.SceneView,
   portal: Portal,

--- a/src/functionality/search.ts
+++ b/src/functionality/search.ts
@@ -49,7 +49,8 @@ interface SearchConfiguration {
 export function createSearch(
   view: __esri.MapView | __esri.SceneView,
   portal: Portal,
-  searchConfiguration: SearchConfiguration
+  searchConfiguration: SearchConfiguration,
+  popupHover?: boolean
 ): Search {
   const DEFAULT_PLACEHOLDER = "Find address or place";
   const INCLUDE_DEFAULT_SOURCES = "includeDefaultSources";
@@ -126,6 +127,29 @@ export function createSearch(
     },
     { once: true, initial: true }
   );
+
+  searchWidget.on("search-complete", () => {
+    if (searchWidget.popupEnabled) {
+      // Handle setting focus on popup and then back
+      // to search box
+      if (popupHover) view.popupEnabled = true;
+      when(
+        () => view?.popup?.viewModel?.active === true,
+        () => {
+          view.popup.focus();
+          when(
+            () => view?.popup?.visible === false,
+            () => {
+              searchWidget.focus();
+              if (popupHover) view.popupEnabled = false;
+            },
+            { initial: true, once: true }
+          );
+        },
+        { initial: true, once: true }
+      );
+    }
+  });
 
   return searchWidget;
 }


### PR DESCRIPTION
Problem:
Apps that use `createSearch` are unable to leverage the `search-complete` callback logic because it currently resides within `addSearch`.

Solution:
Refactor the code by relocating the `search-complete` callback logic from `addSearch` to `createSearch`. This change ensures that `createSearch` and `addSearch` (calls `createSearch`) can both use the `search-complete` callback functionality.