### PR TITLE
Removed Duplicate App title setting

### DIFF
--- a/src/configParamsJSON/webEditorConfigParams.ts
+++ b/src/configParamsJSON/webEditorConfigParams.ts
@@ -18,12 +18,6 @@ export default {
               content: [
                 {
                   type: "setting",
-                  id: "title",
-                  defaultValue: "",
-                  express: true
-                },
-                {
-                  type: "setting",
                   id: "header",
                   express: true,
                   defaultValue: true,


### PR DESCRIPTION
Web Editor configuration had App Title setting listed twice. Updated WE configJSON to remove the duplicate setting.

https://devtopia.esri.com/WebGIS/arcgis-web-editor/issues/1843

![2025-06-12_10-52-58](https://github.com/user-attachments/assets/c17da5cf-d7b0-4204-ad1b-d8d55b08579b)
