### PR TITLE
chore(gallery): add new config value for useOrgCategories

### DIFF
--- a/src/configParamsJSON/galleryConfigParams.ts
+++ b/src/configParamsJSON/galleryConfigParams.ts
@@ -125,7 +125,10 @@ export default {
                   "type": "setting",
                   "id": "useOrgCategories",
                   "express": true,
-                  "defaultValue": "group"
+                  "defaultValue": false,
+                  "config": {
+                    "categorySettingType": "radio"
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## Summary
Add a new configuration setting to support a radio button control for `useOrgCategories` instead of the default switch control. 

Also, not sure why I set "group" as the default value when it should be a boolean `¯\_(ツ)_/¯`